### PR TITLE
Export adapters and laws.

### DIFF
--- a/fantasy-check.js
+++ b/fantasy-check.js
@@ -1,3 +1,27 @@
-var check = require('./src/check');
+var check = require('./src/check'),
+    // Adapters.
+    jasmine = require('./src/adapters/jasmine'),
+    mocha = require('./src/adapters/mocha'),
+    nodeunit = require('./src/adapters/nodeunit'),
+    // Laws.
+    applicative = require('./src/laws/applicative'),
+    functor = require('./src/laws/functor'),
+    monad = require('./src/laws/monad'),
+    monoid = require('./src/laws/monoid'),
+    semigroup = require('./src/laws/semigroup');
 
-exports = module.exports = check;
+λ = check
+    .property('adapters', {
+        jasmine: jasmine,
+        mocha: mocha,
+        nodeunit: nodeunit
+    })
+    .property('laws', {
+        applicative: applicative,
+        functor: functor,
+        monad: monad,
+        monoid: monoid,
+        semigroup: semigroup
+    });
+
+exports = module.exports = λ;


### PR DESCRIPTION
Makes it easier for those using this library to grab what they need. Also, if things get restructured, we don't end up breaking everyone's tests.
