### PR TITLE
mocha adapter: just throw an error

### DIFF
--- a/src/adapters/mocha.js
+++ b/src/adapters/mocha.js
@@ -21,14 +21,11 @@ var λ = require('../check'),
           var report = env.forAll(property, args),
               result = report.fold(
                   function(fail) {
-                      return 'Failed after ' + fail.tries + ' tries: ' + fail.inputs.toString();
+                      throw new Error('Failed after ' + fail.tries + ' tries: ' + fail.inputs.toString());
                   },
                   function() {
-                      return 'OK';
                   }
               );
-
-          assert.equal(result == 'OK');
       };
   });
 


### PR DESCRIPTION
Small bug in the following line:

```js
assert.equal(result == 'OK');
```

It should be

```js
assert.equal(result, 'OK');
```

However, the mocha adapter can simply throw an error.